### PR TITLE
Hide Cup's link.

### DIFF
--- a/2023/html/index.html
+++ b/2023/html/index.html
@@ -20,7 +20,7 @@
 
       <li><a href="./index.html">About PWS</a></li>
 
-      <li><a href="./cup22.html">PWSCUP2022</a></li>
+      <!-- <li><a href="./cup23.html">PWSCUP2023</a></li> -->
 
       <li><a href="https://www.iwsec.org/pws">Past PWS</a></li>
     </ul>

--- a/2023/html/index_e.html
+++ b/2023/html/index_e.html
@@ -20,7 +20,7 @@
 
       <li><a href="./index_e.html">About PWS</a></li>
 
-      <li><a href="./cup22_e.html">PWSCUP2022</a></li>
+      <!-- <li><a href="./cup23_e.html">PWSCUP2023</a></li> -->
 
       <li><a href="https://www.iwsec.org/pws/index_e.html">Past
       PWS</a></li>

--- a/2023/index.html
+++ b/2023/index.html
@@ -20,7 +20,7 @@
 
       <li><a href="./index.html">About PWS</a></li>
 
-      <li><a href="./cup22.html">PWSCUP2022</a></li>
+      <!-- <li><a href="./cup23.html">PWSCUP2023</a></li> -->
 
       <li><a href="https://www.iwsec.org/pws">Past PWS</a></li>
     </ul>

--- a/2023/index_e.html
+++ b/2023/index_e.html
@@ -20,7 +20,7 @@
 
       <li><a href="./index_e.html">About PWS</a></li>
 
-      <li><a href="./cup22_e.html">PWSCUP2022</a></li>
+      <!-- <li><a href="./cup23_e.html">PWSCUP2023</a></li> -->
 
       <li><a href="https://www.iwsec.org/pws/index_e.html">Past
       PWS</a></li>

--- a/2023/template/header_afterTitle.html
+++ b/2023/template/header_afterTitle.html
@@ -9,9 +9,11 @@
         <li>
           <a href="./index.html">About PWS</a>
         </li>
+        <!--
         <li>
-          <a href="./cup22.html">PWSCUP2022</a>
+          <a href="./cup23.html">PWSCUP2023</a>
         </li>
+        -->
         <li>
           <a href="https://www.iwsec.org/pws">Past PWS</a>
         </li>

--- a/2023/template/header_afterTitle_e.html
+++ b/2023/template/header_afterTitle_e.html
@@ -9,9 +9,11 @@
         <li>
           <a href="./index_e.html">About PWS</a>
         </li>
+        <!--
         <li>
-          <a href="./cup22_e.html">PWSCUP2022</a>
+          <a href="./cup23_e.html">PWSCUP2023</a>
         </li>
+        -->
         <li>
           <a href="https://www.iwsec.org/pws/index_e.html">Past PWS</a>
         </li>


### PR DESCRIPTION
Cup2023のページを作るまで、一旦リンクを隠す。