### PR TITLE
iPWS2023 日付の修正と管理システム改修

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,15 @@ jobs:
             - "81:a1:ee:97:71:d9:ea:53:50:82:fc:e4:b0:a3:a7:f3"
  
       - run:
-          name: Start deploy
+          name: Deploy
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then  
-                ssh -o StrictHostKeyChecking=no $USER_NAME@$HOST_NAME "cd /var/www/html/pws/; git pull origin master"
+                ssh -o StrictHostKeyChecking=no $USER_NAME@$HOST_NAME -o UserKnownHostsFile=/dev/null "cd /var/www/html/pws/; git pull origin master"
             fi  
 
       - run:
-          name: Make html file
+          name: Build and Test
           command: |
             if [ "${CIRCLE_BRANCH}" == "gh-pages" ]; then  
-                ssh -o StrictHostKeyChecking=no $TEST_USER_NAME@$TEST_HOST_NAME "cd /tmp/pwssite; git pull origin gh-pages; git checkout gh-pages; bash ./make.bash; git add -A; git commit -m 'make.bash'; git push origin gh-pages"
+                ssh -o StrictHostKeyChecking=no $TEST_USER_NAME@$TEST_HOST_NAME -o UserKnownHostsFile=/dev/null "cd /tmp/pwssite; git pull origin gh-pages; git checkout gh-pages; bash ./make.bash; git add -A; git commit -m 'make.bash'; git push origin gh-pages"
             fi  

--- a/ipws2023/html/index.html
+++ b/ipws2023/html/index.html
@@ -123,40 +123,40 @@
 
       <tbody>
         <tr class="odd">
-          <td align="left">May 14 - June 2, 2023.</td>
+          <td align="left">May 14th - June 2nd, 2023.</td>
 
           <td align="left">Team registration</td>
         </tr>
 
         <tr class="even">
-          <td align="left">June 5 - June 19, 2023.</td>
+          <td align="left">June 5th - June 19th, 2023.</td>
 
           <td align="left">Preliminary round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">June 26 - July 10, 2023.</td>
+          <td align="left">June 26th - July 10th, 2023.</td>
 
           <td align="left">Preliminary round 2 Attack (2
           weeks)</td>
         </tr>
 
         <tr class="even">
-          <td align="left">July 24 - Aug. 7, 2023.</td>
+          <td align="left">July 24th - Aug. 7th, 2023.</td>
 
           <td align="left">Final round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">Aug. 14 - Aug. 21, 2023.</td>
+          <td align="left">Aug. 14th - Aug. 21st, 2023.</td>
 
           <td align="left">Final round 2 Attack (2 weeks)</td>
         </tr>
 
         <tr class="even">
-          <td align="left">Aug. 29, 2023.</td>
+          <td align="left">Aug. 29th, 2023.</td>
 
           <td align="left">Final presentation in Yokohama.</td>
         </tr>

--- a/ipws2023/html/index.html
+++ b/ipws2023/html/index.html
@@ -33,7 +33,7 @@
       <p><img src="./Images/teaser.jpg" width="50%"></p>
     </div>
 
-    <h2>What's New (JST)</h2>
+    <h2>What's New</h2>
 
     <ul>
       <li>May 27th, 2023: Corrected dates of the Final Round.</li>
@@ -117,7 +117,7 @@
     <table>
       <thead>
         <tr class="header">
-          <th align="left">Date (JST)</th>
+          <th align="left">Date</th>
 
           <th align="left">Event</th>
         </tr>

--- a/ipws2023/html/index.html
+++ b/ipws2023/html/index.html
@@ -33,7 +33,7 @@
       <p><img src="./Images/teaser.jpg" width="50%"></p>
     </div>
 
-    <h2>What's New</h2>
+    <h2>What's New (JST)</h2>
 
     <ul>
       <li>May 14th, 2023: Registration period has started!</li>
@@ -115,7 +115,7 @@
     <table>
       <thead>
         <tr class="header">
-          <th align="left">Date</th>
+          <th align="left">Date (JST)</th>
 
           <th align="left">Event</th>
         </tr>

--- a/ipws2023/html/index.html
+++ b/ipws2023/html/index.html
@@ -36,6 +36,8 @@
     <h2>What's New (JST)</h2>
 
     <ul>
+      <li>May 27th, 2023: Corrected dates of the Final Round.</li>
+
       <li>May 14th, 2023: Registration period has started!</li>
 
       <li>Mar. 9th, 2023: Opened this page.</li>
@@ -143,14 +145,14 @@
         </tr>
 
         <tr class="even">
-          <td align="left">July 24th - Aug. 7th, 2023.</td>
+          <td align="left">July 17th - July 31st, 2023.</td>
 
           <td align="left">Final round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">Aug. 14th - Aug. 21st, 2023.</td>
+          <td align="left">Aug. 7th - Aug. 21st, 2023.</td>
 
           <td align="left">Final round 2 Attack (2 weeks)</td>
         </tr>

--- a/ipws2023/html/index.html
+++ b/ipws2023/html/index.html
@@ -123,7 +123,7 @@
 
       <tbody>
         <tr class="odd">
-          <td align="left">May 10 - June 2, 2023.</td>
+          <td align="left">May 14 - June 2, 2023.</td>
 
           <td align="left">Team registration</td>
         </tr>

--- a/ipws2023/index.html
+++ b/ipws2023/index.html
@@ -123,40 +123,40 @@
 
       <tbody>
         <tr class="odd">
-          <td align="left">May 14 - June 2, 2023.</td>
+          <td align="left">May 14th - June 2nd, 2023.</td>
 
           <td align="left">Team registration</td>
         </tr>
 
         <tr class="even">
-          <td align="left">June 5 - June 19, 2023.</td>
+          <td align="left">June 5th - June 19th, 2023.</td>
 
           <td align="left">Preliminary round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">June 26 - July 10, 2023.</td>
+          <td align="left">June 26th - July 10th, 2023.</td>
 
           <td align="left">Preliminary round 2 Attack (2
           weeks)</td>
         </tr>
 
         <tr class="even">
-          <td align="left">July 24 - Aug. 7, 2023.</td>
+          <td align="left">July 24th - Aug. 7th, 2023.</td>
 
           <td align="left">Final round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">Aug. 14 - Aug. 21, 2023.</td>
+          <td align="left">Aug. 14th - Aug. 21st, 2023.</td>
 
           <td align="left">Final round 2 Attack (2 weeks)</td>
         </tr>
 
         <tr class="even">
-          <td align="left">Aug. 29, 2023.</td>
+          <td align="left">Aug. 29th, 2023.</td>
 
           <td align="left">Final presentation in Yokohama.</td>
         </tr>

--- a/ipws2023/index.html
+++ b/ipws2023/index.html
@@ -33,7 +33,7 @@
       <p><img src="./Images/teaser.jpg" width="50%"></p>
     </div>
 
-    <h2>What's New (JST)</h2>
+    <h2>What's New</h2>
 
     <ul>
       <li>May 27th, 2023: Corrected dates of the Final Round.</li>
@@ -117,7 +117,7 @@
     <table>
       <thead>
         <tr class="header">
-          <th align="left">Date (JST)</th>
+          <th align="left">Date</th>
 
           <th align="left">Event</th>
         </tr>

--- a/ipws2023/index.html
+++ b/ipws2023/index.html
@@ -33,7 +33,7 @@
       <p><img src="./Images/teaser.jpg" width="50%"></p>
     </div>
 
-    <h2>What's New</h2>
+    <h2>What's New (JST)</h2>
 
     <ul>
       <li>May 14th, 2023: Registration period has started!</li>
@@ -115,7 +115,7 @@
     <table>
       <thead>
         <tr class="header">
-          <th align="left">Date</th>
+          <th align="left">Date (JST)</th>
 
           <th align="left">Event</th>
         </tr>

--- a/ipws2023/index.html
+++ b/ipws2023/index.html
@@ -36,6 +36,8 @@
     <h2>What's New (JST)</h2>
 
     <ul>
+      <li>May 27th, 2023: Corrected dates of the Final Round.</li>
+
       <li>May 14th, 2023: Registration period has started!</li>
 
       <li>Mar. 9th, 2023: Opened this page.</li>
@@ -143,14 +145,14 @@
         </tr>
 
         <tr class="even">
-          <td align="left">July 24th - Aug. 7th, 2023.</td>
+          <td align="left">July 17th - July 31st, 2023.</td>
 
           <td align="left">Final round 1 Anonymization (2
           weeks)</td>
         </tr>
 
         <tr class="odd">
-          <td align="left">Aug. 14th - Aug. 21st, 2023.</td>
+          <td align="left">Aug. 7th - Aug. 21st, 2023.</td>
 
           <td align="left">Final round 2 Attack (2 weeks)</td>
         </tr>

--- a/ipws2023/index.html
+++ b/ipws2023/index.html
@@ -123,7 +123,7 @@
 
       <tbody>
         <tr class="odd">
-          <td align="left">May 10 - June 2, 2023.</td>
+          <td align="left">May 14 - June 2, 2023.</td>
 
           <td align="left">Team registration</td>
         </tr>

--- a/ipws2023/markdown/index.md
+++ b/ipws2023/markdown/index.md
@@ -5,7 +5,7 @@
 <img src="./Images/teaser.jpg" width=50%>
 </div>
 
-## What's New
+## What's New (JST)
 - May  14th, 2023: Registration period has started!
 - Mar.  9th, 2023: Opened this page.
 
@@ -39,7 +39,7 @@ In the story of iPWS Cup 2023, we intend to provide health data that contain dia
 </dl>
 
 ## iPWS Cup 2023 Schedule
-| Date | Event |
+| Date (JST) | Event |
 | :--- | :---- |
 | May  14th - June  2nd, 2023. | Team registration |
 | June  5th - June 19th, 2023. | Preliminary round 1 Anonymization (2 weeks) |

--- a/ipws2023/markdown/index.md
+++ b/ipws2023/markdown/index.md
@@ -6,6 +6,7 @@
 </div>
 
 ## What's New (JST)
+- May  27th, 2023: Corrected dates of the Final Round.
 - May  14th, 2023: Registration period has started!
 - Mar.  9th, 2023: Opened this page.
 
@@ -44,8 +45,8 @@ In the story of iPWS Cup 2023, we intend to provide health data that contain dia
 | May  14th - June  2nd, 2023. | Team registration |
 | June  5th - June 19th, 2023. | Preliminary round 1 Anonymization (2 weeks) |
 | June 26th - July 10th, 2023. | Preliminary round 2 Attack (2 weeks) |
-| July 24th - Aug.  7th, 2023. | Final round 1 Anonymization (2 weeks) |
-| Aug. 14th - Aug. 21st, 2023. | Final round 2 Attack (2 weeks) |
+| July 17th - July 31st, 2023. | Final round 1 Anonymization (2 weeks) |
+| Aug.  7th - Aug. 21st, 2023. | Final round 2 Attack (2 weeks) |
 | Aug. 29th, 2023. | Final presentation in Yokohama.  |
 
 ## How to participate in the iPWS Cup 2023

--- a/ipws2023/markdown/index.md
+++ b/ipws2023/markdown/index.md
@@ -5,7 +5,7 @@
 <img src="./Images/teaser.jpg" width=50%>
 </div>
 
-## What's New (JST)
+## What's New
 - May  27th, 2023: Corrected dates of the Final Round.
 - May  14th, 2023: Registration period has started!
 - Mar.  9th, 2023: Opened this page.
@@ -40,7 +40,7 @@ In the story of iPWS Cup 2023, we intend to provide health data that contain dia
 </dl>
 
 ## iPWS Cup 2023 Schedule
-| Date (JST) | Event |
+| Date | Event |
 | :--- | :---- |
 | May  14th - June  2nd, 2023. | Team registration |
 | June  5th - June 19th, 2023. | Preliminary round 1 Anonymization (2 weeks) |

--- a/ipws2023/markdown/index.md
+++ b/ipws2023/markdown/index.md
@@ -41,12 +41,12 @@ In the story of iPWS Cup 2023, we intend to provide health data that contain dia
 ## iPWS Cup 2023 Schedule
 | Date | Event |
 | :--- | :---- |
-| May  14 - June  2, 2023. | Team registration |
-| June  5 - June 19, 2023. | Preliminary round 1 Anonymization (2 weeks) |
-| June 26 - July 10, 2023. | Preliminary round 2 Attack (2 weeks) |
-| July 24 - Aug.  7, 2023. | Final round 1 Anonymization (2 weeks) |
-| Aug. 14 - Aug. 21, 2023. | Final round 2 Attack (2 weeks) |
-| Aug. 29, 2023. | Final presentation in Yokohama.  |
+| May  14th - June  2nd, 2023. | Team registration |
+| June  5th - June 19th, 2023. | Preliminary round 1 Anonymization (2 weeks) |
+| June 26th - July 10th, 2023. | Preliminary round 2 Attack (2 weeks) |
+| July 24th - Aug.  7th, 2023. | Final round 1 Anonymization (2 weeks) |
+| Aug. 14th - Aug. 21st, 2023. | Final round 2 Attack (2 weeks) |
+| Aug. 29th, 2023. | Final presentation in Yokohama.  |
 
 ## How to participate in the iPWS Cup 2023
 ### Team requirement


### PR DESCRIPTION
- Final Round の日付が1週間しかなかったため2週間化
- CicleCIでGCPへsshする際、毎回異なるIPアドレスが偶然過去のアドレスと一致すると、known_hostsの記載と齟齬が生じてsshエラーとなっていたため、これを改修（known_hostsを生成しない仕様に変更）